### PR TITLE
Added support for environment variable interpolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ target
 .settings
 .project
 .classpath
+
+# IDE
+.idea
+*.iml

--- a/modules/logger/file/log4jdbc-logger-file-core/pom.xml
+++ b/modules/logger/file/log4jdbc-logger-file-core/pom.xml
@@ -32,5 +32,10 @@
 			<groupId>com.github.marcosemiao.util</groupId>
 			<artifactId>service-provider</artifactId>
 		</dependency>
+
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-configuration2</artifactId>
+		</dependency>
 	</dependencies>
 </project>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -88,6 +88,12 @@
 			</dependency>
 
 			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-configuration2</artifactId>
+				<version>2.1.1</version>
+			</dependency>
+
+			<dependency>
 				<groupId>junit</groupId>
 				<artifactId>junit</artifactId>
 				<version>4.12</version>


### PR DESCRIPTION
Added commons configuration to allow for interpolation of environment variables in log4jdbc configuration. This lets you do something like:

`log4jdbc.file=${sys:log_folder}/log4jdbc.log`

This is helpful when trying to debug an application in place (e.g. in Tomcat) and you need to separate log4jdbc output from standard console messaging.